### PR TITLE
Remove golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ This will:
   - [yq](https://mikefarah.gitbook.io/yq/)
   - [Node.js](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions)
   - [Go](https://golang.org/)
-    - [golangci-lint](https://golangci-lint.run/)
   - [GitHub CLI](https://cli.github.com/)
   - [AWS CLI](https://aws.amazon.com/cli/)
   - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/)

--- a/ansible/roles/wsl/tasks/go.yml
+++ b/ansible/roles/wsl/tasks/go.yml
@@ -10,7 +10,3 @@
     path: "$HOME/.bashrc"
     line: 'export PATH="${GOPATH}/bin:${PATH}"'
     state: present
-
-- name: Install golangci-lint
-  shell:
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest


### PR DESCRIPTION
This can be installed per repo rather than globally.
