### PR TITLE
Install pip and venv for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This will:
   - [yq](https://mikefarah.gitbook.io/yq/)
   - [Node.js](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions)
   - [Go](https://golang.org/)
+  - [pip and venv](https://docs.microsoft.com/en-us/windows/python/web-frameworks#install-python-pip-and-venv)
   - [GitHub CLI](https://cli.github.com/)
   - [AWS CDK CLI](https://github.com/aws/aws-cdk)
   - [AWS CLI](https://aws.amazon.com/cli/)

--- a/ansible/roles/wsl/vars/main.yml
+++ b/ansible/roles/wsl/vars/main.yml
@@ -10,6 +10,8 @@ apt_packages:
   - cowsay
   - golang-go
   - awscli
+  - python3-pip
+  - python3-venv
 
 node_packages:
   - aws-cdk


### PR DESCRIPTION
Ubuntu already has Python 3 installed but not pip or venv.