### PR TITLE
updates

### DIFF
--- a/ansible/roles/wsl/tasks/apt.yml
+++ b/ansible/roles/wsl/tasks/apt.yml
@@ -1,4 +1,22 @@
 ---
+- name: Remove deprecated Ansible PPA
+  become: yes
+  ansible.builtin.apt_repository:
+    repo: ppa:ansible/ansible
+    state: absent
+
+- name: Remove deprecated Go PPA
+  become: yes
+  ansible.builtin.apt_repository:
+    repo: ppa:longsleep/golang-backports
+    state: absent
+
+- name: Remove existing Liquibase repository before apt upgrade
+  become: yes
+  ansible.builtin.deb822_repository:
+    name: liquibase
+    state: absent
+
 - name: Update and upgrade apt packages
   become: yes
   ansible.builtin.apt:

--- a/ansible/roles/wsl/tasks/azure.yml
+++ b/ansible/roles/wsl/tasks/azure.yml
@@ -1,4 +1,5 @@
 ---
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#install-azure-cli
 - name: Install the Azure CLI
-  ansible.builtin.shell: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  become: yes
+  ansible.builtin.shell: curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/ansible/roles/wsl/tasks/bash.yml
+++ b/ansible/roles/wsl/tasks/bash.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add git branch in to bash prompt
   ansible.builtin.blockinfile:
-    dest: $HOME/.bashrc
+    dest: "{{ ansible_env.HOME }}/.bashrc"
     block: |
       parse_git_branch() {
         git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'

--- a/ansible/roles/wsl/tasks/go.yml
+++ b/ansible/roles/wsl/tasks/go.yml
@@ -1,41 +1,19 @@
 ---
-# https://go.dev/wiki/Ubuntu
-- name: Add PPA repository for golang
-  become: yes
-  apt_repository:
-    repo: ppa:longsleep/golang-backports
-
-- name: Update apt packages
-  become: yes
-  ansible.builtin.apt:
-    update_cache: yes
-
+# Install the Ubuntu-packaged Go toolchain.
 - name: Install golang
   become: yes
   ansible.builtin.apt:
     name: golang-go
-    state: latest
-
-- name: Add GOPATH in bashrc
-  lineinfile:
-    path: "$HOME/.bashrc"
-    line: 'export GOPATH=$HOME/go'
     state: present
 
-- name: Update PATH with GOPATH in bashrc
+- name: Add Go bin directory to PATH in bashrc
   lineinfile:
-    path: "$HOME/.bashrc"
-    line: 'export PATH="${GOPATH}/bin:${PATH}"'
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    line: 'export PATH="$HOME/go/bin:$PATH"'
     state: present
 
-- name: Add GOPATH in zshrc
+- name: Add Go bin directory to PATH in zshrc
   lineinfile:
-    path: "$HOME/.zshrc"
-    line: 'export GOPATH=$HOME/go'
-    state: present
-
-- name: Update PATH with GOPATH in zshrc
-  lineinfile:
-    path: "$HOME/.zshrc"
-    line: 'export PATH="${GOPATH}/bin:${PATH}"'
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    line: 'export PATH="$HOME/go/bin:$PATH"'
     state: present

--- a/ansible/roles/wsl/tasks/liquibase.yml
+++ b/ansible/roles/wsl/tasks/liquibase.yml
@@ -1,6 +1,13 @@
 ---
-# https://docs.liquibase.com/start/install/liquibase-linux-debian-ubuntu.html1
-- name: Add Liquibase apt repository using key from URL
+# https://docs.liquibase.com/start/install/liquibase-linux-debian-ubuntu.html
+- name: Download Liquibase apt signing key
+  become: yes
+  ansible.builtin.get_url:
+    url: https://repo.liquibase.com/liquibase.asc
+    dest: /usr/share/keyrings/liquibase.asc
+    mode: '0644'
+
+- name: Add Liquibase apt repository
   become: yes
   ansible.builtin.deb822_repository:
     name: liquibase
@@ -9,7 +16,7 @@
     suites: stable
     components: main
     architectures: amd64
-    signed_by: https://repo.liquibase.com/liquibase.asc
+    signed_by: /usr/share/keyrings/liquibase.asc
 
 - name: Update apt packages
   become: yes
@@ -20,4 +27,4 @@
   become: yes
   ansible.builtin.apt:
     name: liquibase
-    state: latest
+    state: present

--- a/ansible/roles/wsl/tasks/zsh.yml
+++ b/ansible/roles/wsl/tasks/zsh.yml
@@ -2,30 +2,30 @@
 - name: Install oh-my-zsh
   shell: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
   args:
-    creates: $HOME/.oh-my-zsh
+    creates: "{{ ansible_env.HOME }}/.oh-my-zsh"
 
 - name: "Configure the zsh theme"
   replace:
-    path: $HOME/.zshrc
+    path: "{{ ansible_env.HOME }}/.zshrc"
     regexp: '^ZSH_THEME=".+"'
     replace: 'ZSH_THEME="conradhodge"'
 
 - name: "Configure the zsh plugins"
   replace:
-    path: $HOME/.zshrc
+    path: "{{ ansible_env.HOME }}/.zshrc"
     regexp: '^plugins=\(.+\)'
     replace: 'plugins=(docker gh git golang npm)'
 
 - name: "Configure zsh to disable auto title"
   replace:
-    path: $HOME/.zshrc
+    path: "{{ ansible_env.HOME }}/.zshrc"
     regexp: '^# +DISABLE_AUTO_TITLE="true"'
     replace: 'DISABLE_AUTO_TITLE="true"'
 
 - name: Copy zsh theme over
   copy:
     src: conradhodge.zsh-theme
-    dest: ~/.oh-my-zsh/custom/themes
+    dest: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/themes"
     mode: 0644
     force: yes
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
+#!/usr/bin/env bash
+
 sudo apt update
 sudo apt upgrade
 sudo apt install make
-sudo apt install software-properties-common
-sudo add-apt-repository --yes --update ppa:ansible/ansible
 sudo apt install ansible


### PR DESCRIPTION
- ansible/roles/wsl/tasks/go.yml now installs Go from Ubuntus own golang-go package with state: present, removes the extra Go PPA logic, stops exporting GOPATH, and only adds $HOME/go/bin to PATH.
- ansible/roles/wsl/tasks/bash.yml and ansible/roles/wsl/tasks/zsh.yml now use {{ ansible_env.HOME }} instead of shell-style $HOME paths, so Ansible edits the correct files reliably.
- ansible/roles/wsl/tasks/apt.yml now removes three stale apt sources before the initial update/upgrade: the old Ansible PPA, the old Go PPA, and any existing Liquibase repository definition.
- ansible/roles/wsl/tasks/liquibase.yml now downloads the Liquibase signing key into liquibase.asc and uses that local keyring in signed_by, instead of pointing signed_by at a remote URL. It also installs Liquibase with state: present.
- ansible/roles/wsl/tasks/azure.yml now uses become: yes and runs the installer as bash directly, instead of piping into sudo bash, which was breaking under Ansible.
- setup.sh no longer adds the deprecated Ansible PPA, installs ansible directly from Ubuntu, and now has a shebang so it is treated as a proper shell script.