### PR TITLE
Fix shell profile paths and clean up broken APT sources

### DIFF
--- a/ansible/roles/wsl/tasks/apt.yml
+++ b/ansible/roles/wsl/tasks/apt.yml
@@ -17,6 +17,12 @@
     name: liquibase
     state: absent
 
+- name: Remove GitHub CLI repository (disabled due to repo issues)
+  become: yes
+  ansible.builtin.deb822_repository:
+    name: github-cli
+    state: absent
+
 - name: Update and upgrade apt packages
   become: yes
   ansible.builtin.apt:

--- a/ansible/roles/wsl/tasks/cows.yml
+++ b/ansible/roles/wsl/tasks/cows.yml
@@ -1,12 +1,12 @@
 ---
 - name: Randomise those cow in bashrc!
   ansible.builtin.lineinfile:
-    path: "$HOME/.bashrc"
+    path: "{{ ansible_env.HOME }}/.bashrc"
     line: 'export ANSIBLE_COW_SELECTION=random'
     state: present
 
 - name: Randomise those cows in zshrc!
   ansible.builtin.lineinfile:
-    path: "$HOME/.zshrc"
+    path: "{{ ansible_env.HOME }}/.zshrc"
     line: 'export ANSIBLE_COW_SELECTION=random'
     state: present

--- a/ansible/roles/wsl/tasks/tmpreaper.yml
+++ b/ansible/roles/wsl/tasks/tmpreaper.yml
@@ -1,12 +1,12 @@
 ---
 - name: Run tmpreaper in bashrc to clean the tmp directory
   ansible.builtin.lineinfile:
-    path: "$HOME/.bashrc"
+    path: "{{ ansible_env.HOME }}/.bashrc"
     line: 'tmpreaper 7d /tmp'
     state: present
 
 - name: Run tmpreaper in zshrc to clean the tmp directory
   ansible.builtin.lineinfile:
-    path: "$HOME/.zshrc"
+    path: "{{ ansible_env.HOME }}/.zshrc"
     line: 'tmpreaper 7d /tmp'
     state: present


### PR DESCRIPTION
- Replace $HOME with {{ ansible_env.HOME }} in tmpreaper.yml and cows.yml
- Remove GitHub CLI repository during apt cleanup since task is disabled